### PR TITLE
Implement token refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This package aims to provide a consistent interface for handling OAuth 2.0 authe
 *   Sign in with Apple now includes dynamic client secret generation. You should still verify the returned ID token in your application.
 *   Basic GoDoc comments have been added.
 *   An example server demonstrates usage (`examples/simple_server/main.go`).
+*   Tokens can be refreshed via `OAuthHandler.RefreshToken`.
 *   **Testing is currently missing.**
 
 ## Supported Providers (Partial List)

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,13 @@
 module github.com/Suhaibinator/GOAuth
 
-go 1.23
+go 1.24.0
+
+toolchain go1.24.3
 
 require golang.org/x/oauth2 v0.30.0
 
 require (
-	cloud.google.com/go/compute/metadata v0.6.0 // indirect
+	cloud.google.com/go/compute/metadata v0.7.0 // indirect
 	github.com/stretchr/testify v1.10.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Suhaibinator/GOAuth
 
-go 1.24.3
+go 1.23
 
 require golang.org/x/oauth2 v0.30.0
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 cloud.google.com/go/compute/metadata v0.6.0 h1:A6hENjEsCDtC1k8byVsgwvVcioamEHvZ4j01OwKxG9I=
 cloud.google.com/go/compute/metadata v0.6.0/go.mod h1:FjyFAW1MW0C203CEOMDTu3Dk1FlqW3Rga40jzHL4hfg=
+cloud.google.com/go/compute/metadata v0.7.0 h1:PBWF+iiAerVNe8UCHxdOt6eHLVc3ydFeOCw78U8ytSU=
+cloud.google.com/go/compute/metadata v0.7.0/go.mod h1:j5MvL9PprKL39t166CoB1uVHfQMs4tFQZZcKwksXUjo=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=


### PR DESCRIPTION
## Summary
- allow OAuth tokens to be refreshed
- support Apple refresh flow
- mention `RefreshToken` in docs
- adjust go mod version for local toolchain

## Testing
- `go build ./...` *(fails: no route to host)*
- `go test ./...` *(fails: no route to host)*