### PR TITLE
Introduce provider interface

### DIFF
--- a/pkg/auth/apple.go
+++ b/pkg/auth/apple.go
@@ -38,6 +38,19 @@ type AppleOauthHandler struct {
 	HTTPClient  *http.Client
 }
 
+// appleProvider implements the Provider interface for Sign in with Apple.
+type appleProvider struct {
+	handler *OAuthHandler
+}
+
+func (a *appleProvider) AuthURL(ctx context.Context, state string) string {
+	return a.handler.GetAppleAuthURL(ctx, state)
+}
+
+func (a *appleProvider) Login(ctx context.Context, code string) (*User, error) {
+	return a.handler.appleLoginWithCode(ctx, code)
+}
+
 // generateClientSecret creates the JWT client secret required by Apple.
 func (a *AppleOauthHandler) generateClientSecret() (string, error) {
 	now := time.Now()
@@ -261,12 +274,12 @@ func (o *OAuthHandler) GetAppleAuthURL(ctx context.Context, state string) string
 }
 
 // registerAppleOAuth initializes the Apple OAuth handler using the configuration values.
-func (o *OAuthHandler) registerAppleOAuth(ctx context.Context) error {
+func (o *OAuthHandler) registerAppleOAuth(ctx context.Context) (Provider, error) {
 	logger := o.logEnricher(ctx, o.logger).Named("register_apple")
 	if o.config.AppleOAuthClientID == "" || o.config.AppleOAuthTeamID == "" ||
 		o.config.AppleOAuthKeyID == "" || o.config.AppleOAuthPrivateKey == "" {
 		logger.Error("Apple OAuth configuration incomplete")
-		return errors.New("apple OAuth requires client id, team id, key id and private key")
+		return nil, errors.New("apple OAuth requires client id, team id, key id and private key")
 	}
 
 	handler, err := NewAppleOauthHandler(
@@ -282,7 +295,7 @@ func (o *OAuthHandler) registerAppleOAuth(ctx context.Context) error {
 	}
 	o.appleOauthHandler = handler
 	logger.Info("Apple OAuth handler registered")
-	return nil
+	return &appleProvider{handler: o}, nil
 }
 
 // Refresh exchanges a refresh token for a new access token using Apple's token endpoint.

--- a/pkg/auth/provider.go
+++ b/pkg/auth/provider.go
@@ -1,0 +1,11 @@
+package auth
+
+import "context"
+
+// Provider defines the common interface implemented by all OAuth providers.
+type Provider interface {
+	// AuthURL generates the provider-specific authorization URL for the given state.
+	AuthURL(ctx context.Context, state string) string
+	// Login exchanges an authorization code for a User.
+	Login(ctx context.Context, code string) (*User, error)
+}


### PR DESCRIPTION
## Summary
- add Provider interface for OAuth implementations
- implement Provider in each provider module
- store providers in a map inside `OAuthHandler`
- register providers into that map
- simplify `LoginWithCode` to use the provider map

## Testing
- `go vet ./...` *(fails: go.mod requires go >= 1.24.0 (running go 1.23.8; GOTOOLCHAIN=local))*